### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@ Android
 
 \# TODO
 
-##Compatibility
+## Compatibility
 
 Not tested yet. 
 
-##Running on Device
+## Running on Device
 
 https://facebook.github.io/react-native/docs/running-on-device-ios.html#content
 
-##Known Bugs
+## Known Bugs
 
 ## Day 1
 An IOS-system-like stop watch.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
