### PR TITLE
fix: 修复项目的package.json依赖

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "react-native-gesture-password": "^0.2.0",
     "react-native-linear-gradient": "^1.5.13",
     "react-native-maps": "^0.11.0",
-    "react-native-scrollable-tab-view": "^0.6.0",
+    "react-native-scrollable-tab-view": "0.6.0",
     "react-native-swipe-cards": "0.0.9",
     "react-native-swiper": "^1.4.9",
-    "react-native-vector-icons": "^2.0.3",
+    "react-native-vector-icons": "^4.3.0",
     "react-native-video": "^0.9.0"
   }
 }


### PR DESCRIPTION
react-native-scrollable-tab-view 最新版需要rn4.4以上支持
react-native-vector-icons 旧版添加link后，会出现Redefinition of 'RCTLogLevel' error错误