### PR TITLE
fix:days2实例显示不出来

### DIFF
--- a/view/day2.js
+++ b/view/day2.js
@@ -156,7 +156,7 @@ class Weather extends Component{
     });
 
     return(
-      <View>
+      <View style={{ flex: 1 }}>
         <Swiper 
         style={styles.wrapper} 
         showsButtons={false}
@@ -189,6 +189,9 @@ export default class extends Component{
 }
 
 const styles = StyleSheet.create({
+  weatherContainer: {
+    flex: 1,
+  },
   pageContainer:{
     backgroundColor:"transparent",
     position: "absolute",


### PR DESCRIPTION
1，填补weatherContainer样式，之前没写
2，为Weather组件的render方法最外层增加style={{ flex: 1 }}属性，要不然显示不出来啊